### PR TITLE
[Feat] 워크스페이스 오너/멤버 권한 검증 메서드 추가

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace/repository/WorkspaceMemberRepository.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/repository/WorkspaceMemberRepository.java
@@ -4,7 +4,9 @@ import com.project.PJA.workspace.entity.WorkspaceMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
     List<WorkspaceMember> findAllByUser_UserId(Long userId);
+    Optional<WorkspaceMember> findByWorkspace_WorkspaceIdAndUser_UserId(Long workspaceId, Long userId);
 }

--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -172,4 +172,28 @@ public class WorkspaceService {
                 foundWorkspace.getUser().getUserId(),
                 foundWorkspace.getProgressStep());
     }
+
+    // 사용자가 오너가 아니면 403 반환
+    public void authorizeOwnerOrThrow(Long userId, Long workspaceId, String message) {
+        // 워크스페이스 찾기
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new NotFoundException("요청하신 워크스페이스를 찾을 수 없습니다."));
+        
+        // 사용자가 해당 워크스페이스의 오너인지 확인
+        if (!foundWorkspace.getUser().getUserId().equals(userId)) {
+            throw new ForbiddenException(message);
+        }
+    }
+
+    // 사용자가 오너 or 멤버가 아니면 403 반환
+    public void authorizeOwnerOrMemberOrThrow(Long userId, Long workspaceId, String message) {
+        // 워크스페이스 멤버 찾기
+        WorkspaceMember member = workspaceMemberRepository.findByWorkspace_WorkspaceIdAndUser_UserId(workspaceId, userId)
+                .orElseThrow(() -> new NotFoundException("이 워크스페이스에 접근할 권한이 없습니다."));
+
+        // 사용자가 오너 or 멤버인지 확인
+        if (member.getWorkspaceRole() != WorkspaceRole.OWNER && member.getWorkspaceRole() != WorkspaceRole.MEMBER) {
+            throw new ForbiddenException(message);
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #37 

## 📝작업 내용
- 워크스페이스 오너 권한 검증 메서드(authorizeOwnerOrThrow) 추가
- 오너 또는 멤버 권한 검증 메서드(authorizeOwnerOrMemberOrThrow) 추가
- 권한 관련 예외 처리 로직을 메서드로 분리하여 재사용성 및 유지보수성 개선

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
