### PR TITLE
[Fix] refresh token을 통한 access token 재발급 문제 해결

### DIFF
--- a/PJA/src/main/java/com/project/PJA/security/controller/AuthController.java
+++ b/PJA/src/main/java/com/project/PJA/security/controller/AuthController.java
@@ -54,9 +54,9 @@ public class AuthController {
 
 
     @PostMapping("/reissue")
-    public ResponseEntity<SuccessResponse<?>> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
-        log.info("== 토큰 재발급 API 진입 == RT: {}", tokenRequestDto.getRefreshToken());
-        String newAccessToken = authUserService.reissue(tokenRequestDto.getRefreshToken());
+    public ResponseEntity<SuccessResponse<?>> reissue(HttpServletRequest request) {
+        log.info("== 토큰 재발급 API 진입 ==");
+        String newAccessToken = authUserService.reissue(request);
 
         SuccessResponse<?> response = new SuccessResponse<>("success", "토큰 재발급에 성공하였습니다.", Map.of("accessToken", newAccessToken));
         return new ResponseEntity<>(response, HttpStatus.CREATED);


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->


## 📝작업 내용
- 프론트에서 쿠키 접근 불가능으로 백엔드에서 request를 받아서 refresh token을 쿠키에서 꺼내고, access token 재발급 하는 방식으로 변경함

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
