### PR TITLE
[Feat] 워크스페이스 조회 시 공개 여부 포함 및 단일 조회 기능 구현

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
@@ -53,8 +53,8 @@ public class WorkspaceController {
     // 워크스페이스 수정
     @PutMapping("/{workspaceId}")
     public ResponseEntity<SuccessResponse<WorkspaceResponse>> updateWorkspace(@AuthenticationPrincipal Users user,
-                                @PathVariable Long workspaceId,
-                                @RequestBody WorkspaceUpdateRequest workspaceUpdateRequest) {
+                                                                              @PathVariable Long workspaceId,
+                                                                              @RequestBody WorkspaceUpdateRequest workspaceUpdateRequest) {
         Long userId = user.getUserId();
         WorkspaceResponse updatedWorkspace = workspaceService.updateWorkspace(userId, workspaceId, workspaceUpdateRequest);
 
@@ -65,7 +65,7 @@ public class WorkspaceController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 워크스페이스 진행도 완료 수정
+    // 워크스페이스 진행도 상태 수정
     @PatchMapping("/{workspaceId}/complete")
     public ResponseEntity<SuccessResponse<WorkspaceResponse>> updateCompletionStatus(@AuthenticationPrincipal Users user,
                                                                                      @PathVariable Long workspaceId,
@@ -97,8 +97,8 @@ public class WorkspaceController {
     // 워크스페이스 팀원 초대 메일 전송
     @PostMapping("/{workspaceId}/invite")
     public ResponseEntity<SuccessResponse<WorkspaceInviteResponse>> inviteUserToWorkspace(@AuthenticationPrincipal Users user,
-                                                                       @PathVariable Long workspaceId,
-                                                                       @RequestBody WorkspaceInviteRequest workspaceInviteRequest) {
+                                                                                          @PathVariable Long workspaceId,
+                                                                                          @RequestBody WorkspaceInviteRequest workspaceInviteRequest) {
         Long userId = user.getUserId();
         WorkspaceInviteResponse workspaceInviteResponse = invitationService.sendInvitation(userId, workspaceId, workspaceInviteRequest);
 

--- a/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
@@ -36,6 +36,20 @@ public class WorkspaceController {
         return new ResponseEntity<>(response,HttpStatus.OK);
     }
 
+    // 워크스페이스 단일 조회
+    @GetMapping("/{workspaceId}")
+    public ResponseEntity<SuccessResponse<WorkspaceResponse>> getWorkspace(@AuthenticationPrincipal Users user,
+                                                                           @PathVariable Long workspaceId) {
+        Long userId = user.getUserId();
+        WorkspaceResponse workspace = workspaceService.getWorkspace(userId, workspaceId);
+
+        SuccessResponse<WorkspaceResponse> response = new SuccessResponse<>(
+                "success","워크스페이스 정보를 성공적으로 조회했습니다.", workspace
+        );
+
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
+
     // 워크스페이스 생성
     @PostMapping({ "", "/" })
     public ResponseEntity<SuccessResponse<WorkspaceResponse>> createWorkspace(@AuthenticationPrincipal Users user,

--- a/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceResponse.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceResponse.java
@@ -12,6 +12,7 @@ public class WorkspaceResponse {
     private Long workspaceId;
     private String projectName;
     private String teamName;
+    private Boolean isPublic;
     private Long ownerId;
     private ProgressStep progressStep;
 

--- a/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceUpdateRequest.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceUpdateRequest.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class WorkspaceUpdateRequest {
     private String projectName;
     private String teamName;
+    private Boolean isPublic;
 }

--- a/PJA/src/main/java/com/project/PJA/workspace/entity/Workspace.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/entity/Workspace.java
@@ -53,9 +53,10 @@ public class Workspace {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void update(String projectName, String teamName) {
+    public void update(String projectName, String teamName, Boolean isPublic) {
         this.projectName = projectName;
         this.teamName = teamName;
+        this.isPublic = isPublic;
     }
 
     public void updateIsCompleted(ProgressStep progressStep) {

--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -52,11 +52,31 @@ public class WorkspaceService {
                         workspace.getWorkspaceId(),
                         workspace.getProjectName(),
                         workspace.getTeamName(),
+                        workspace.getIsPublic(),
                         workspace.getUser().getUserId(),
                         workspace.getProgressStep()))
                 .collect(Collectors.toList());
 
         return userWorkspaceList;
+    }
+
+    // 워크스페이스의 단일 조회
+    @Transactional(readOnly = true)
+    public WorkspaceResponse getWorkspace(Long userId, Long workspaceId) {
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new NotFoundException("요청하신 워크스페이스를 찾을 수 없습니다."));
+
+        // 사용자 확인
+        validateWorkspaceAccess(userId, foundWorkspace);
+
+        return new WorkspaceResponse(
+                foundWorkspace.getWorkspaceId(),
+                foundWorkspace.getProjectName(),
+                foundWorkspace.getTeamName(),
+                foundWorkspace.getIsPublic(),
+                foundWorkspace.getUser().getUserId(),
+                foundWorkspace.getProgressStep()
+        );
     }
 
     // 워크스페이스 생성
@@ -99,6 +119,7 @@ public class WorkspaceService {
                 savedWorkspace.getWorkspaceId(),
                 savedWorkspace.getProjectName(),
                 savedWorkspace.getTeamName(),
+                savedWorkspace.getIsPublic(),
                 savedWorkspace.getUser().getUserId(),
                 savedWorkspace.getProgressStep());
     }
@@ -122,6 +143,7 @@ public class WorkspaceService {
                 foundWorkspace.getWorkspaceId(),
                 workspaceUpdateRequest.getProjectName(),
                 workspaceUpdateRequest.getTeamName(),
+                workspaceUpdateRequest.getIsPublic(),
                 foundWorkspace.getUser().getUserId(),
                 foundWorkspace.getProgressStep());
     }
@@ -146,6 +168,7 @@ public class WorkspaceService {
                 foundWorkspace.getWorkspaceId(),
                 foundWorkspace.getProjectName(),
                 foundWorkspace.getTeamName(),
+                foundWorkspace.getIsPublic(),
                 foundWorkspace.getUser().getUserId(),
                 foundWorkspace.getProgressStep());
     }
@@ -169,6 +192,7 @@ public class WorkspaceService {
                 foundWorkspace.getWorkspaceId(),
                 foundWorkspace.getProjectName(),
                 foundWorkspace.getTeamName(),
+                foundWorkspace.getIsPublic(),
                 foundWorkspace.getUser().getUserId(),
                 foundWorkspace.getProgressStep());
     }

--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -111,17 +111,17 @@ public class WorkspaceService {
                 .orElseThrow(() -> new NotFoundException("요청하신 워크스페이스를 찾을 수 없습니다."));
 
         // 사용자가 해당 워크스페이스의 오너가 아니면 403 반환
-        if(foundWorkspace.getUser().getUserId() != userId) {
+        if(!foundWorkspace.getUser().getUserId().equals(userId)) {
             throw new ForbiddenException("이 워크스페이스를 수정할 권한이 없습니다.");
         }
 
         // 해당 워크스페이스의 오너이면 수정
-        foundWorkspace.update(workspaceUpdateRequest.getProjectName(), workspaceUpdateRequest.getTeamName());
+        foundWorkspace.update(workspaceUpdateRequest.getProjectName(), workspaceUpdateRequest.getTeamName(), workspaceUpdateRequest.getIsPublic());
 
         return new WorkspaceResponse(
                 foundWorkspace.getWorkspaceId(),
-                foundWorkspace.getProjectName(),
-                foundWorkspace.getTeamName(),
+                workspaceUpdateRequest.getProjectName(),
+                workspaceUpdateRequest.getTeamName(),
                 foundWorkspace.getUser().getUserId(),
                 foundWorkspace.getProgressStep());
     }
@@ -134,7 +134,7 @@ public class WorkspaceService {
                 .orElseThrow(() -> new NotFoundException("요청하신 워크스페이스를 찾을 수 없습니다."));
 
         // 사용자가 해당 워크스페이스의 오너가 아니면 403 반환
-        if(foundWorkspace.getUser().getUserId() != userId) {
+        if(!foundWorkspace.getUser().getUserId().equals(userId)) {
             throw new ForbiddenException("이 워크스페이스를 수정할 권한이 없습니다.");
         }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #68 

## 📝작업 내용
- 워크스페이스 단일 조회로 해당 워크스페이스의 정보를 반환하는 기능을 추가했습니다.
- 워크스페이스 반환 시 공개 여부 정보를 포함하도록 추가했습니다.

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
