### PR TITLE
[Fix] Workspace 삭제 시 FeatureCategory 외래키 제약조건 위반 문제 해결

### DIFF
--- a/PJA/src/main/java/com/project/PJA/project_progress/entity/FeatureCategory.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/entity/FeatureCategory.java
@@ -1,17 +1,13 @@
 package com.project.PJA.project_progress.entity;
 
 import com.project.PJA.workspace.entity.Workspace;
-import com.project.PJA.workspace.entity.WorkspaceMember;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Getter
 @Setter
@@ -29,6 +25,7 @@ public class FeatureCategory {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Workspace workspace; // 워크스페이스
 
     private String name; // 이름
@@ -39,13 +36,10 @@ public class FeatureCategory {
     @Column(name = "has_test")
     private Boolean hasTest; // 테스트 여부
 
-
     @Column(name = "order_index")
     private Integer orderIndex; // 순서(리스트 상의 순서)
 
     @Builder.Default
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Feature> features = new ArrayList<>();
-
-
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #110 

## 📝작업 내용
FeatureCategory에 있는 Workspace 외래키에 CASCADE 설정을 추가하여 해당 Workspace가 삭제되면 FeatureCategory도 같이 삭제되게 수정했습니다.

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
