### PR TITLE
[Fix] 초대 메일 텍스트에서 링크로 수정

### DIFF
--- a/PJA/src/main/java/com/project/PJA/email/service/EmailServiceImpl.java
+++ b/PJA/src/main/java/com/project/PJA/email/service/EmailServiceImpl.java
@@ -1,8 +1,11 @@
 package com.project.PJA.email.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,12 +15,47 @@ public class EmailServiceImpl implements EmailService {
 
     @Override
     public void sendInvitationEmail(String to, String inviteUrl) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(to);
-        message.setSubject("PJA의 워크스페이스 초대 메일입니다.");
-        message.setText("아래 링크를 클릭하여 워크스페이스에 참여하세요:\n\n" + inviteUrl);
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
 
-        mailSender.send(message);
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            helper.setTo(to);
+            helper.setSubject("\uD83D\uDCE7 PJA의 워크스페이스 초대 메일입니다.");
+
+            /*String htmlContent = """
+    <p>안녕하세요,<br>
+    PJA 워크스페이스에 초대드립니다. 🎉</p>
+    <br>
+    <p>아래 버튼을 클릭하여 워크스페이스에 참여해 주세요.</p>
+    <br>
+    <p><a href="%s" style="display:inline-block;padding:10px 20px;
+    background-color:#FE5000;color:white;text-decoration:none;
+    border-radius:5px;">워크스페이스 참여하기</a></p>
+
+    <p>감사합니다. 🙏</p>
+    """.formatted(inviteUrl);*/
+
+            String htmlContent = """
+    <p style="margin:0 0 16px 0;">안녕하세요,<br>
+    PJA 워크스페이스에 초대드립니다. 🎉</p>
+
+    <p style="margin:0 0 16px 0;">아래 버튼을 클릭하여 워크스페이스에 참여해 주세요.</p>
+
+    <p style="margin:0 0 16px 0;">
+        <a href="%s" style="display:inline-block;padding:10px 20px;
+        background-color:#FE5000;color:white;text-decoration:none;
+        border-radius:5px;">워크스페이스 참여하기</a>
+    </p>
+
+    <p style="margin:0 0 16px 0;">감사합니다. 🙏</p>
+""".formatted(inviteUrl);
+
+            helper.setText(htmlContent, true);
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 전송 실패" + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/PJA/src/main/java/com/project/PJA/ideainput/service/IdeaInputService.java
+++ b/PJA/src/main/java/com/project/PJA/ideainput/service/IdeaInputService.java
@@ -126,6 +126,7 @@ public class IdeaInputService {
     }
     
     // 메인 기능 생성
+    @Transactional
     public MainFunctionData createMainFunction(Long userId, Long workspaceId, Long ideaInputId) {
         IdeaInput foundIdeaInput = ideaInputRepository.findById(ideaInputId)
                 .orElseThrow(() -> new NotFoundException("요청하신 아이디어 입력을 찾을 수 없습니다."));
@@ -143,6 +144,7 @@ public class IdeaInputService {
     }
 
     // 메인 기능 삭제
+    @Transactional
     public MainFunctionData deleteMainFunction(Long userId, Long workspaceId, Long mainFunctionId) {
         workspaceService.authorizeOwnerOrMemberOrThrow(userId, workspaceId, "이 워크스페이스에 삭제할 권한이 없습니다.");
 
@@ -158,6 +160,7 @@ public class IdeaInputService {
     }
     
     // 기술 스택 생성
+    @Transactional
     public TechStackData createTechStack(Long userId, Long workspaceId, Long ideaInputId) {
         IdeaInput foundIdeaInput = ideaInputRepository.findById(ideaInputId)
                 .orElseThrow(() -> new NotFoundException("요청하신 아이디어 입력을 찾을 수 없습니다."));
@@ -175,6 +178,7 @@ public class IdeaInputService {
     }
 
     // 기술 스택 삭제
+    @Transactional
     public TechStackData deleteTechStack(Long userId, Long workspaceId, Long techStackId) {
         workspaceService.authorizeOwnerOrMemberOrThrow(userId, workspaceId, "이 워크스페이스에 삭제할 권한이 없습니다.");
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #120 

## 📝작업 내용
- 초대 링크를 텍스트에서 HTML 형식의 이메일로 수정하여 링크를 클릭할 수 있게 수정했습니다.
- @Transactional 누락으로 인한 삭제 반영 안 되었던 문제를 수정하였습니다.

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
