### PR TITLE
[Feat] 워크스페이스 Entity 및 설정 수정 기능에 깃허브 링크 추가

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/controller/WorkspaceController.java
@@ -40,12 +40,12 @@ public class WorkspaceController {
 
     // 워크스페이스 단일 조회
     @GetMapping("/{workspaceId}")
-    public ResponseEntity<SuccessResponse<WorkspaceResponse>> getWorkspace(@AuthenticationPrincipal Users user,
-                                                                           @PathVariable Long workspaceId) {
+    public ResponseEntity<SuccessResponse<WorkspaceDetailResponse>> getWorkspace(@AuthenticationPrincipal Users user,
+                                                                                 @PathVariable Long workspaceId) {
         Long userId = user.getUserId();
-        WorkspaceResponse workspace = workspaceService.getWorkspace(userId, workspaceId);
+        WorkspaceDetailResponse workspace = workspaceService.getWorkspace(userId, workspaceId);
 
-        SuccessResponse<WorkspaceResponse> response = new SuccessResponse<>(
+        SuccessResponse<WorkspaceDetailResponse> response = new SuccessResponse<>(
                 "success","워크스페이스 정보를 성공적으로 조회했습니다.", workspace
         );
 
@@ -67,15 +67,15 @@ public class WorkspaceController {
     
     // 워크스페이스 수정
     @PutMapping("/{workspaceId}")
-    public ResponseEntity<SuccessResponse<WorkspaceResponse>> updateWorkspace(@AuthenticationPrincipal Users user,
-                                                                              @PathVariable Long workspaceId,
-                                                                              @RequestBody WorkspaceUpdateRequest workspaceUpdateRequest) {
+    public ResponseEntity<SuccessResponse<WorkspaceDetailResponse>> updateWorkspace(@AuthenticationPrincipal Users user,
+                                                                                    @PathVariable Long workspaceId,
+                                                                                    @RequestBody WorkspaceUpdateRequest workspaceUpdateRequest) {
         Long userId = user.getUserId();
         log.info("=== workspace 수정 API 진입 == userId: {}", userId);
 
-        WorkspaceResponse updatedWorkspace = workspaceService.updateWorkspace(user, workspaceId, workspaceUpdateRequest);
+        WorkspaceDetailResponse updatedWorkspace = workspaceService.updateWorkspace(user, workspaceId, workspaceUpdateRequest);
 
-        SuccessResponse<WorkspaceResponse> response = new SuccessResponse<>(
+        SuccessResponse<WorkspaceDetailResponse> response = new SuccessResponse<>(
                 "success", "요청하신 워크스페이스가 성공적으로 수정되었습니다.", updatedWorkspace
         );
 

--- a/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceDetailResponse.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceDetailResponse.java
@@ -1,0 +1,23 @@
+package com.project.PJA.workspace.dto;
+
+import com.project.PJA.workspace.enumeration.ProgressStep;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkspaceDetailResponse {
+    private Long workspaceId;
+    private String projectName;
+    private String teamName;
+    private Boolean isPublic;
+    private Long ownerId;
+    private ProgressStep progressStep;
+    private String githubUrl;
+
+    public String getProgressStep() {
+        return progressStep.getValue();
+    }
+}

--- a/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceUpdateRequest.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/dto/WorkspaceUpdateRequest.java
@@ -11,4 +11,5 @@ public class WorkspaceUpdateRequest {
     private String projectName;
     private String teamName;
     private Boolean isPublic;
+    private String githubUrl;
 }

--- a/PJA/src/main/java/com/project/PJA/workspace/entity/Workspace.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/entity/Workspace.java
@@ -44,6 +44,9 @@ public class Workspace {
     @Column(name = "progress_step", nullable = false, length = 10)
     private ProgressStep progressStep = ProgressStep.ZERO;
 
+    @Column(name = "github_url")
+    private String githubUrl;
+
     @Builder
     public Workspace(Users user, String projectName, String teamName, Boolean isPublic) {
         this.user = user;
@@ -53,10 +56,11 @@ public class Workspace {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void update(String projectName, String teamName, Boolean isPublic) {
+    public void update(String projectName, String teamName, Boolean isPublic, String githubUrl) {
         this.projectName = projectName;
         this.teamName = teamName;
         this.isPublic = isPublic;
+        this.githubUrl = githubUrl;
     }
 
     public void updateOwner(Users user) {


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #153 

## 📝작업 내용
- Workspace 엔티티에 github 필드 추가
- 워크스페이스 단일 조회 응답용 DTO 추가
- 워크스페이스 전체 조회 결과를 최신순(리버스)으로 반환하도록 변경
- 워크스페이스 수정 시 필수 필드에 대한 유효성 검증 로직 추가 (projectName, teamName, isPublic)
- 워크스페이스 수정 기능에 github 수정 로직 반영

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
