### PR TITLE
[Chore] security에서 sse 구독 api는 인증 없이 접근 가능하게 허용

### DIFF
--- a/PJA/src/main/java/com/project/PJA/security/config/SecurityConfig.java
+++ b/PJA/src/main/java/com/project/PJA/security/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/login/oauth2/**",
                                 "/oauth2/**",
-                                "/api/workspaces/project-info").permitAll()
+                                "/api/workspaces/project-info",
+                                "/api/workspaces/**/noti/subscribe").permitAll()
                         .anyRequest().authenticated()
                 )
 //                .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->


## 📝작업 내용
security에서 sse 구독 api는 인증 없이 접근 가능하게 허용

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
