### PR TITLE
[Fix] 멤버 삭제할 때 오너도 삭제되는 문제 해결

### DIFF
--- a/PJA/src/main/java/com/project/PJA/member/service/MemberService.java
+++ b/PJA/src/main/java/com/project/PJA/member/service/MemberService.java
@@ -125,6 +125,10 @@ public class MemberService {
 
         workspaceService.authorizeOwnerOrThrow(userId, foundWorkspace, "멤버를 삭제할 권한이 없습니다.");
 
+        if (userId.equals(memberId)) {
+            throw new BadRequestException("해당 워크스페이스의 오너는 삭제할 수 없습니다.");
+        }
+
         // 최근 활동 기록 추가
         workspaceActivityService.addWorkspaceActivity(foundWorkspaceMember.getUser(), workspaceId, ActivityTargetType.MEMBER, ActivityActionType.LEAVE);
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #259 

## 📝작업 내용
멤버 삭제 시, 오너가 자신의 계정을 삭제할 수 있었던 버그가 있었습니다.
삭제 대상 멤버의 ID와 오너의 ID를 비교하여, 같을 경우 400 에러를 반환하도록 수정했습니다.

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
