### PR TITLE
[Feat] 워크스페이스 진행도 완료 수정에 6에서 5로도 수정 기능 추가

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -211,10 +211,16 @@ public class WorkspaceService {
         authorizeOwnerOrThrow(userId, foundWorkspace, "이 워크스페이스를 수정할 권한이 없습니다.");
 
         // 해당 워크스페이스의 오너이면 수정
-        if (foundWorkspace.getProgressStep() != ProgressStep.FIVE) {
+        /*if (foundWorkspace.getProgressStep() != ProgressStep.FIVE) {
+            throw new BadRequestException("해당 워크스페이스를 완료하지 않았습니다.");
+        }*/
+        if (foundWorkspace.getProgressStep() == ProgressStep.FIVE) {
+            foundWorkspace.updateProgressStep(ProgressStep.SIX);
+        } else if (foundWorkspace.getProgressStep() == ProgressStep.SIX) {
+            foundWorkspace.updateProgressStep(ProgressStep.FIVE);
+        } else {
             throw new BadRequestException("해당 워크스페이스를 완료하지 않았습니다.");
         }
-        foundWorkspace.updateProgressStep(ProgressStep.SIX);
 
         return new WorkspaceResponse(
                 foundWorkspace.getWorkspaceId(),

--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -211,9 +211,6 @@ public class WorkspaceService {
         authorizeOwnerOrThrow(userId, foundWorkspace, "이 워크스페이스를 수정할 권한이 없습니다.");
 
         // 해당 워크스페이스의 오너이면 수정
-        /*if (foundWorkspace.getProgressStep() != ProgressStep.FIVE) {
-            throw new BadRequestException("해당 워크스페이스를 완료하지 않았습니다.");
-        }*/
         if (foundWorkspace.getProgressStep() == ProgressStep.FIVE) {
             foundWorkspace.updateProgressStep(ProgressStep.SIX);
         } else if (foundWorkspace.getProgressStep() == ProgressStep.SIX) {


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #261 

## 📝작업 내용
기존에는 워크스페이스 진행도를 '수정'(5)에서 '완료'(6)로만 변경할 수 있었지만, 이제 '완료'(6)에서 '수정'(5)으로도 되돌릴 수 있도록 기능을 추가했습니다.

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
