### PR TITLE
[Fix] 유사한 워크스페이스 검색 시 본인 워크스페이스 제외

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace/service/WorkspaceService.java
@@ -294,6 +294,7 @@ public class WorkspaceService {
             List<Workspace> workspaces = workspaceRepository.findAllById(workspaceIds.getProject_ID());
 
             List<WorkspaceResponse> workspaceResponses = workspaces.stream()
+                    .filter(workspace -> !workspace.getWorkspaceId().equals(workspaceId)) // 유사한 워크스페이스 중 본인의 워크스페이스는 제외
                     .map(workspace -> new WorkspaceResponse(
                             workspace.getWorkspaceId(),
                             workspace.getProjectName(),


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #264 

## 📝작업 내용
유사한 워크스페이스 검색 시, 현재 사용자가 소속된 워크스페이스가 결과에 포함되는 문제를 수정하여 본인의 워크스페이스는 검색 결과에서 제외했습니다.

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
