### PR TITLE
[Fix] 워크스페이스 최근활동의 유저 정보를 현재의 값으로 가져오게 수정

### DIFF
--- a/PJA/src/main/java/com/project/PJA/workspace_activity/entity/WorkspaceActivity.java
+++ b/PJA/src/main/java/com/project/PJA/workspace_activity/entity/WorkspaceActivity.java
@@ -30,9 +30,9 @@ public class WorkspaceActivity {
 
     @Column(name = "user_id")
     private Long userId;
-    private String username;
-    @Column(name = "user_profile")
-    private String userProfile;
+//    private String username;
+//    @Column(name = "user_profile")
+//    private String userProfile;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/PJA/src/main/java/com/project/PJA/workspace_activity/service/WorkspaceActivityService.java
+++ b/PJA/src/main/java/com/project/PJA/workspace_activity/service/WorkspaceActivityService.java
@@ -2,6 +2,7 @@ package com.project.PJA.workspace_activity.service;
 
 import com.project.PJA.exception.NotFoundException;
 import com.project.PJA.user.entity.Users;
+import com.project.PJA.user.repository.UserRepository;
 import com.project.PJA.workspace.entity.Workspace;
 import com.project.PJA.workspace.repository.WorkspaceRepository;
 import com.project.PJA.workspace.service.WorkspaceService;
@@ -27,19 +28,21 @@ public class WorkspaceActivityService {
     private final WorkspaceActivityRepository workspaceActivityRepository;
     private final WorkspaceRepository workspaceRepository;
     private final WorkspaceService workspaceService;
+    private final UserRepository userRepository;
 
-    public WorkspaceActivityService(WorkspaceActivityRepository workspaceActivityRepository, WorkspaceRepository workspaceRepository, WorkspaceService workspaceService) {
+    public WorkspaceActivityService(WorkspaceActivityRepository workspaceActivityRepository, WorkspaceRepository workspaceRepository, WorkspaceService workspaceService, UserRepository userRepository) {
         this.workspaceActivityRepository = workspaceActivityRepository;
         this.workspaceRepository = workspaceRepository;
         this.workspaceService = workspaceService;
+        this.userRepository = userRepository;
     }
 
     @Transactional
     public void addWorkspaceActivity(Users user, Long workspaceId, ActivityTargetType targetType, ActivityActionType actionType) {
         WorkspaceActivity workspaceActivity = new WorkspaceActivity();
         workspaceActivity.setUserId(user.getUserId());
-        workspaceActivity.setUsername(user.getUsername());
-        workspaceActivity.setUserProfile(user.getProfileImage());
+//        workspaceActivity.setUsername(user.getUsername());
+//        workspaceActivity.setUserProfile(user.getProfileImage());
         workspaceActivity.setWorkspaceId(workspaceId);
         workspaceActivity.setTargetType(targetType);
         workspaceActivity.setActionType(actionType);
@@ -62,8 +65,12 @@ public class WorkspaceActivityService {
         for (WorkspaceActivity activity : workspaceActivityList) {
             WorkspaceActivityResponseDto dto = new WorkspaceActivityResponseDto();
 
-            dto.setUsername(activity.getUsername());
-            dto.setUserProfile(activity.getUserProfile());
+            Users foundUser = userRepository.findById(activity.getUserId())
+                            .orElseThrow(()
+                                    -> new NotFoundException("[WorkspaceActivityService] getWorkspaceActivities에서 유저 정보를 찾을 수 없습니다."));
+
+            dto.setUsername(foundUser.getUsername());
+            dto.setUserProfile(foundUser.getProfileImage());
             dto.setActionType(activity.getActionType().getKorean());
             dto.setTargetType(activity.getTargetType().getKorean());
             dto.setRelativeDateLabel(getRelativeDate(activity.getCreatedAt()));


### PR DESCRIPTION
## #️⃣ 이슈 번호
closed #273


## 📝작업 내용
워크스페이스 최근활동의 유저 정보(이름, 프로필 이미지)를 UserId로 Users 객체 찾아, 현재 Users의 이름, 프로필 값으로 가져오게 수정함

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
