### PR TITLE
[Fix] action post의 수정 content가 null 또는 empty일 때 빈 문자열이 들어가도록 변경

### DIFF
--- a/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
@@ -96,7 +96,8 @@ public class ActionPostService {
             throw new ForbiddenException("액션 포스트가 해당 액션에 속하지 않습니다.");
         }
 
-        actionPost.setContent(content);
+        if(content == null || content.isEmpty()) actionPost.setContent("");
+        else actionPost.setContent(content);
 
         // 기존 파일 삭제
         for (ActionPostFile file : actionPost.getActionPostFiles()) {


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->


## 📝작업 내용
action post의 수정 content가 null 또는 empty일 때 빈 문자열("")이 들어가도록 변경

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
