### PR TITLE
[Fix] 편집 시작과 종료 요청이 동시에 발생할 경우 404 오류 발생 문제 수정

### DIFF
--- a/PJA/src/main/java/com/project/PJA/editing/controller/EditingController.java
+++ b/PJA/src/main/java/com/project/PJA/editing/controller/EditingController.java
@@ -29,6 +29,8 @@ public class EditingController {
         Long userId = user.getUserId();
         String userName = user.getName();
         String userProfile = user.getProfileImage();
+        log.info("=== 편집 시작 API 진입 == userId: {}", userId);
+
         EditingResponse editingResponse = editingService.startEditing(userId, userName, userProfile, workspaceId, editingRequest);
 
         SuccessResponse<EditingResponse> response = new SuccessResponse<>(
@@ -46,6 +48,8 @@ public class EditingController {
         Long userId = user.getUserId();
         String userName = user.getName();
         String userProfile = user.getProfileImage();
+        log.info("=== 편집 유지 API 진입 == userId: {}", userId);
+
         EditingResponse editingResponse = editingService.keepEditing(userId, userName, userProfile, workspaceId, editingRequest);
 
         SuccessResponse<EditingResponse> response = new SuccessResponse<>(
@@ -63,6 +67,8 @@ public class EditingController {
         Long userId = user.getUserId();
         String userName = user.getName();
         String userProfile = user.getProfileImage();
+        log.info("=== 편집 삭제 API 진입 == userId: {}", userId);
+
         EditingResponse editingResponse = editingService.stopEditing(userId, userName, userProfile, workspaceId, editingRequest);
 
         SuccessResponse<EditingResponse> response = new SuccessResponse<>(
@@ -78,12 +84,16 @@ public class EditingController {
                                                                                    @PathVariable Long workspaceId,
                                                                                    @PathVariable String page) {
         Long userId = user.getUserId();
+        log.info("=== 편집 조회 API 진입 == userId: {}", userId);
+        log.info("=== 편집 조회 page: {}", page);
         List<EditingResponse> editingResponses = editingService.getEditingStatus(userId, workspaceId, page);
 
         SuccessResponse<List<EditingResponse>> response = new SuccessResponse<>(
                 "success", "편집 중인 페이지를 조회합니다.", editingResponses
         );
 
+        log.info("=== 편집 조회 data : {}", editingResponses);
+        log.info("=== 편집 조회 성공응답 : {}", response);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/PJA/src/main/java/com/project/PJA/editing/service/EditingService.java
+++ b/PJA/src/main/java/com/project/PJA/editing/service/EditingService.java
@@ -10,12 +10,13 @@ import com.project.PJA.exception.NotFoundException;
 import com.project.PJA.workspace.service.WorkspaceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +32,8 @@ public class EditingService {
     public EditingResponse startEditing(Long userId, String userName, String userProfile, Long workspaceId, EditingRequest request) {
         workspaceService.authorizeOwnerOrMemberOrThrowFromCache(userId, workspaceId);
 
-        String key = makeRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
+        String editingUserKey = makeEditingUserRedisKey(userId);
+        String editingKey = makeEditingRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
 
         EditingUser editingUser = new EditingUser(
                 userId,
@@ -41,87 +43,197 @@ public class EditingService {
                 request.getFieldId()
         );
 
+        String luaScript = """
+                local existingFieldKey = redis.call('get', KEYS[1])
+                if existingFieldKey and existingFieldKey == KEYS[2] then
+                    redis.call('del', existingFieldKey)
+                end
+                redis.call('del', KEYS[1])
+                
+                if redis.call('exists', KEYS[2]) == 1 then
+                    return false
+                end
+                
+                redis.call('set', KEYS[1], ARGV[1], 'EX', 15)
+                redis.call('set', KEYS[2], ARGV[2], 'EX', 15)
+                return true
+                """;
+
+        String jsonEditingUser;
         try {
-            String value = objectMapper.writeValueAsString(editingUser);
-
-            Boolean success = redisTemplate.opsForValue().setIfAbsent(key, value, Duration.ofSeconds(15));
-
-            if (Boolean.FALSE.equals(success)) {
-                throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
-            }
-
-            return new EditingResponse(
-                    userId,
-                    userName,
-                    userProfile,
-                    request.getPage(),
-                    request.getField(),
-                    request.getFieldId()
-            );
+            jsonEditingUser = objectMapper.writeValueAsString(editingUser);
         } catch (JsonProcessingException e) {
+            log.error("편집 시작 직렬화 실패", e);
             throw new RuntimeException("편집 정보 직렬화 실패", e);
         }
+
+        Boolean success = redisTemplate.execute((RedisCallback<Boolean>) connection -> {
+            byte[] lua = redisTemplate.getStringSerializer().serialize(luaScript);
+
+            byte[] key1 = redisTemplate.getStringSerializer().serialize(editingUserKey);
+            byte[] key2 = redisTemplate.getStringSerializer().serialize(editingKey);
+
+            byte[] arg1 = redisTemplate.getStringSerializer().serialize(editingKey);
+            byte[] arg2 = redisTemplate.getStringSerializer().serialize(jsonEditingUser);
+
+            Object evalResult = connection.eval(lua, ReturnType.BOOLEAN, 2, key1, key2, arg1, arg2);
+            return (Boolean) evalResult;
+        });
+
+        if (Boolean.FALSE.equals(success)) {
+            throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
+        }
+
+        return new EditingResponse(
+                userId,
+                userName,
+                userProfile,
+                request.getPage(),
+                request.getField(),
+                request.getFieldId()
+        );
     }
 
     // 편집 유지
     public EditingResponse keepEditing(Long userId, String userName, String userProfile, Long workspaceId, EditingRequest request) {
-        String key = makeRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
-        String value = redisTemplate.opsForValue().get(key);
-        if (value == null) {
-            throw new NotFoundException("요청하신 편집 정보를 찾을 수 없습니다.");
-        }
+        String editingUserKey = makeEditingUserRedisKey(userId);
+        String editingKey = makeEditingRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
 
-        try {
-            EditingUser currentUser = objectMapper.readValue(value, EditingUser.class);
+        String luaScript = """
+                local existingFieldKey = redis.call('get', KEYS[1])
+                if not existingFieldKey or existingFieldKey ~= KEYS[2] then
+                    return "NOT_FOUND"
+                end
+                
+                local editingData = redis.call('get', KEYS[2])
+                if not editingData then
+                    return "NOT_FOUND"
+                end
+                
+                local success, editingUser = pcall(cjson.decode, editingData)
+                if not success then
+                    return "INVALID_JSON"
+                end
+                if editingUser.userId ~= tonumber(ARGV[1]) then
+                    return "CONFLICT"
+                end
+                
+                redis.call('expire', KEYS[1], 15)
+                redis.call('expire', KEYS[2], 15)
+                
+                return "OK"
+                """;
 
-            if (!currentUser.getUserId().equals(userId)) {
-                throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
+        String result = redisTemplate.execute((RedisCallback<String>) connection -> {
+            byte[] lua = redisTemplate.getStringSerializer().serialize(luaScript);
+
+            byte[] key1 = redisTemplate.getStringSerializer().serialize(editingUserKey);
+            byte[] key2 = redisTemplate.getStringSerializer().serialize(editingKey);
+
+            byte[] arg1 = redisTemplate.getStringSerializer().serialize(String.valueOf(userId));
+
+            Object evalResult = connection.eval(lua, ReturnType.VALUE, 2, key1, key2, arg1);
+            if (evalResult instanceof byte[]) {
+                return redisTemplate.getStringSerializer().deserialize((byte[]) evalResult);
+            } else if (evalResult instanceof String) {
+                return (String) evalResult;
+            } else {
+                return null;
             }
+        });
 
-            redisTemplate.expire(key, Duration.ofSeconds(15));
-
-            return new EditingResponse(
-                    userId,
-                    userName,
-                    userProfile,
-                    request.getPage(),
-                    request.getField(),
-                    request.getFieldId()
-            );
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("편집 정보 역직렬화 실패", e);
+        switch (result) {
+            case "OK":
+                break;
+            case "NOT_FOUND":
+                throw new NotFoundException("요청하신 편집 정보를 찾을 수 없습니다.");
+            case "CONFLICT":
+                throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
+            case "INVALID_JSON":
+                throw new RuntimeException("편집 중인 데이터가 손상되어 처리할 수 없습니다.");
+            default:
+                throw new RuntimeException("알 수 없는 Redis 응답: " + result);
         }
+
+        return new EditingResponse(
+                userId,
+                userName,
+                userProfile,
+                request.getPage(),
+                request.getField(),
+                request.getFieldId()
+        );
     }
 
     // 편집 삭제
     public EditingResponse stopEditing(Long userId, String userName, String userProfile, Long workspaceId, EditingRequest request) {
-        String key = makeRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
-        String value = redisTemplate.opsForValue().get(key);
+        String editingUserKey = makeEditingUserRedisKey(userId);
+        String editingKey = makeEditingRedisKey(workspaceId, request.getPage(), request.getField(), request.getFieldId());
 
-        if (value == null) {
-            throw new NotFoundException("요청하신 편집 정보를 찾을 수 없습니다.");
-        }
+        String luaScript = """
+                local existingFieldKey = redis.call('get', KEYS[1])
+                if not existingFieldKey or existingFieldKey ~= KEYS[2] then
+                    return "NOT_FOUND"
+                end
+                
+                local editingData = redis.call('get', KEYS[2])
+                if not editingData then
+                    return "NOT_FOUND"
+                end
+                
+                local success, editingUser = pcall(cjson.decode, editingData)
+                if not success then
+                    return "INVALID_JSON"
+                end
+                if editingUser.userId ~= tonumber(ARGV[1]) then
+                    return "CONFLICT"
+                end
+                
+                redis.call('del', KEYS[1])
+                redis.call('del', KEYS[2])
+                
+                return "OK"
+                """;
 
-        try {
-            EditingUser currentUser = objectMapper.readValue(value, EditingUser.class);
+        String result = redisTemplate.execute((RedisCallback<String>) connection -> {
+            byte[] lua = redisTemplate.getStringSerializer().serialize(luaScript);
 
-            if (!currentUser.getUserId().equals(userId)) {
-                throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
+            byte[] key1 = redisTemplate.getStringSerializer().serialize(editingUserKey);
+            byte[] key2 = redisTemplate.getStringSerializer().serialize(editingKey);
+
+            byte[] arg1 = redisTemplate.getStringSerializer().serialize(String.valueOf(userId));
+
+            Object evalResult = connection.eval(lua, ReturnType.VALUE, 2, key1, key2, arg1);
+            if (evalResult instanceof byte[]) {
+                return redisTemplate.getStringSerializer().deserialize((byte[]) evalResult);
+            } else if (evalResult instanceof String) {
+                return (String) evalResult;
+            } else {
+                return null;
             }
+        });
 
-            redisTemplate.delete(key);
-
-            return new EditingResponse(
-                    userId,
-                    userName,
-                    userProfile,
-                    request.getPage(),
-                    request.getField(),
-                    request.getFieldId()
-            );
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("편집 정보 역직렬화 실패", e);
+        switch (result) {
+            case "OK":
+                break;
+            case "NOT_FOUND":
+                throw new NotFoundException("요청하신 편집 정보를 찾을 수 없습니다.");
+            case "CONFLICT":
+                throw new ConflictException("이미 다른 사용자가 편집 중입니다.");
+            case "INVALID_JSON":
+                throw new RuntimeException("편집 중인 데이터가 손상되어 처리할 수 없습니다.");
+            default:
+                throw new RuntimeException("알 수 없는 Redis 응답: " + result);
         }
+
+        return new EditingResponse(
+                userId,
+                userName,
+                userProfile,
+                request.getPage(),
+                request.getField(),
+                request.getFieldId()
+        );
     }
 
     // 편집 상태 조회
@@ -152,7 +264,7 @@ public class EditingService {
                     String parsedField = null;
                     String parsedFieldId = null;
 
-                    if (page.equals("project-info") || page.equals("apis") || page.equals("action")) {
+                    if ("project-info".equals(page) || "apis".equals(page) || "action".equals(page)) {
                         // editing:data:{workspaceId}:{page}:{fieldId}
                         if (parts.length == 5) {
                             parsedFieldId = parts[4];
@@ -186,11 +298,14 @@ public class EditingService {
             }
         }
 
-
         return responses;
     }
 
-    private String makeRedisKey(Long workspaceId, String page, String field, String fieldId) {
+    private String makeEditingUserRedisKey(Long userId) {
+        return "editing:user:" + userId;
+    }
+
+    private String makeEditingRedisKey(Long workspaceId, String page, String field, String fieldId) {
         if (page.equals("requirements") || page.equals("project-info") || page.equals("apis") || page.equals("action")) {
             // 키 editing:data:{workspaceId}:{page}:{fieldId} 형태 (row 단위)
             return "editing:data:" + workspaceId + ":" + page + ":" + fieldId;


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #270 

## 📝작업 내용
- 편집 시작 시 Redis에 이미 존재하는 사용자의 편집 정보를 삭제하고, 없으면 새로 저장하도록 처리하여 편집 상태를 갱신하도록 구현
- 편집 사용자 정보를 key에 저장하고 값으로 편집 상세 정보를 저장하여 Lua 스크립트로 원자성 확보, 요청/수정/삭제 시 데이터 일관성 보장

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
