### PR TITLE
[Fix] 편집 요청 시, 기존 키 삭제 안 되는 버그 해결

### DIFF
--- a/PJA/src/main/java/com/project/PJA/editing/controller/EditingController.java
+++ b/PJA/src/main/java/com/project/PJA/editing/controller/EditingController.java
@@ -1,5 +1,7 @@
 package com.project.PJA.editing.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.PJA.common.dto.SuccessResponse;
 import com.project.PJA.editing.dto.EditingRequest;
 import com.project.PJA.editing.dto.EditingResponse;
@@ -20,6 +22,7 @@ import java.util.List;
 @RequestMapping("/api/editing")
 public class EditingController {
     private final EditingService editingService;
+    private final ObjectMapper objectMapper;
 
     // 편집 시작
     @PostMapping("/{workspaceId}/start")
@@ -92,8 +95,13 @@ public class EditingController {
                 "success", "편집 중인 페이지를 조회합니다.", editingResponses
         );
 
-        log.info("=== 편집 조회 data : {}", editingResponses);
-        log.info("=== 편집 조회 성공응답 : {}", response);
+        try {
+            String dto = objectMapper.writeValueAsString(editingResponses);
+            log.info("=== 편집 조회 data : {}", dto);
+        } catch (JsonProcessingException e) {
+            log.error("편집 조회 데이터 json 변화 실패", e);
+        }
+
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/PJA/src/main/java/com/project/PJA/editing/service/EditingService.java
+++ b/PJA/src/main/java/com/project/PJA/editing/service/EditingService.java
@@ -45,7 +45,7 @@ public class EditingService {
 
         String luaScript = """
                 local existingFieldKey = redis.call('get', KEYS[1])
-                if existingFieldKey and existingFieldKey == KEYS[2] then
+                if existingFieldKey then
                     redis.call('del', existingFieldKey)
                 end
                 redis.call('del', KEYS[1])


### PR DESCRIPTION
## #️⃣ 이슈 번호
<!-- closed #번호 -->
closed #278 

## 📝작업 내용
- 편집 요청 시, 기존 사용자의 편집 정보가 남아 있어 삭제되지 않는 버그 수정
- Redis Lua 스크립트 내 existingFieldKey == KEYS[2] 조건 제거 후, existingFieldKey가 존재하면 무조건 삭제하도록 변경

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
