### PR TITLE
[Fix] 액션 게시글 사진 첨부 시, 기존 사진 삭제되는 문제 해결

### DIFF
--- a/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
@@ -99,17 +99,9 @@ public class ActionPostService {
         if(content == null || content.isEmpty()) actionPost.setContent("");
         else actionPost.setContent(content);
 
-        // 기존 파일 삭제
-        for (ActionPostFile file : actionPost.getActionPostFiles()) {
-//            fileStorageService.deleteFile(file.getFilePath());
-            s3Service.deleteFile(file.getFilePath());
-        }
-        actionPost.getActionPostFiles().clear();
-
         if(fileList != null && !fileList.isEmpty()) {
             for(MultipartFile file : fileList) {
                 String path = s3Service.uploadFile(file, "action", actionPostId);
-//                String path = fileStorageService.storeFile(file, "action", actionPostId);
                 String type = file.getContentType();
 
                 ActionPostFile postFile = ActionPostFile.builder()


### PR DESCRIPTION
## #️⃣ 이슈 번호
closed #284

## 📝작업 내용
액션 게시글 사진 첨부 시, 기존 사진 삭제되는 문제 해결

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
