### PR TITLE
[Feat] action post 조회 시 반환 값에 actionId 추가 및 댓글 삭제 및 수정 다른 사용자 막기

### DIFF
--- a/PJA/src/main/java/com/project/PJA/project_progress/dto/ActionCommentResponseDto.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/dto/ActionCommentResponseDto.java
@@ -13,5 +13,6 @@ public class ActionCommentResponseDto {
     private Long commentId;
     private String content;
     private String authorName;
+    private Long authorId;
     private LocalDateTime updatedAt;
 }

--- a/PJA/src/main/java/com/project/PJA/project_progress/service/ActionCommentService.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/service/ActionCommentService.java
@@ -102,6 +102,11 @@ public class ActionCommentService {
             throw new ForbiddenException("댓글이 해당 액션에 속하지 않습니다.");
         }
 
+        // 해당 댓글의 작성자가 아니면 댓글 수정 못하게 막기
+        if(!comment.getUser().getUserId().equals(user.getUserId())) {
+            throw new ForbiddenException("댓글을 수정할 권한이 없습니다.");
+        }
+
         comment.setContent(dto.getContent());
         comment.setUpdatedAt(LocalDateTime.now());
 
@@ -123,6 +128,12 @@ public class ActionCommentService {
         if(!comment.getActionPost().getAction().getActionId().equals(actionId)) {
             throw new ForbiddenException("댓글이 해당 액션에 속하지 않습니다.");
         }
+
+        // 해당 댓글의 작성자가 아니면 댓글 수정 못하게 막기
+        if(!comment.getUser().getUserId().equals(user.getUserId())) {
+            throw new ForbiddenException("댓글을 삭제할 권한이 없습니다.");
+        }
+
         actionCommentRepository.delete(comment);
     }
 }

--- a/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
+++ b/PJA/src/main/java/com/project/PJA/project_progress/service/ActionPostService.java
@@ -73,7 +73,8 @@ public class ActionPostService {
                 .map(comment -> ActionCommentResponseDto.builder()
                         .commentId(comment.getActionCommentId())
                         .content(comment.getContent())
-                        .authorName(comment.getUser().getName()) // 또는 nickname
+                        .authorName(comment.getUser().getName()) // 또는
+                        .authorId(comment.getUser().getUserId()) // 작성자의 userId
                         .updatedAt(comment.getUpdatedAt())
                         .build())
                 .toList();


### PR DESCRIPTION
## #️⃣ 이슈 번호
closed #319 


## 📝작업 내용
action post 조회 시 반환 값에 actionId 추가 및 댓글 삭제 및 수정 다른 사용자 막기

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 빌드 설정, 패키지 관리 등 기타 작업
- [ ] 문서 수정
- [ ] 테스트 코드 추가/수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬리뷰 요구사항(선택)
